### PR TITLE
Refactor: Centralize KSP configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,11 +192,12 @@ tasks.register("ciSdkManagerLicenses") {
                 private var counter = 0
                 override fun read(): Int = yesString[counter % 2].also { counter++ }.code
             }
-            exec {
+            providers.exec {
                 executable = sdkManagerFile.absolutePath
                 args = listOf("--list", "--sdk_root=$sdkDirPath")
                 println("exec: ${this.commandLine.joinToString(separator = " ")}")
             }.apply { println("ExecResult: $this") }
+            @Suppress("DEPRECATION")
             exec {
                 executable = sdkManagerFile.absolutePath
                 args = listOf("--licenses", "--sdk_root=$sdkDirPath")
@@ -233,6 +234,7 @@ fun runExec(commands: List<String>): String = object : ByteArrayOutputStream() {
         super.write(p0, p1, p2)
     }
 }.let { resultOutputStream ->
+    @Suppress("DEPRECATION")
     exec {
         if (System.getenv("JAVA_HOME") == null) {
             System.getProperty("java.home")?.let { javaHome ->
@@ -249,7 +251,7 @@ fun runExec(commands: List<String>): String = object : ByteArrayOutputStream() {
 }
 
 fun gradlew(vararg tasks: String, addToSystemProperties: Map<String, String>? = null) {
-    exec {
+    providers.exec {
         executable = File(
             project.rootDir,
             if (Os.isFamily(Os.FAMILY_WINDOWS)) "gradlew.bat" else "gradlew"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
     alias(libs.plugins.android.application)
@@ -11,19 +11,11 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(libs.versions.build.jvmTarget.get().toInt())
+
     androidTarget {
-        compilations.all {
-            compileTaskProvider {
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.fromTarget(libs.versions.build.jvmTarget.get()))
-                    freeCompilerArgs.add(
-                        "-Xjdk-release=${JavaVersion.valueOf(
-                            libs.versions.build.javaVersion.get()
-                        )}"
-                    )
-                }
-            }
-        }
+        // https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     }
 
     jvm()
@@ -120,7 +112,14 @@ compose.desktop {
 }
 
 dependencies {
-    ksp(libs.koin.ksp.compiler)
+    // KSP Tasks
+    add("kspAndroid", libs.koin.ksp.compiler)
+    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
+    add("kspIosArm64", libs.koin.ksp.compiler)
+    add("kspIosSimulatorArm64", libs.koin.ksp.compiler)
+    add("kspIosX64", libs.koin.ksp.compiler)
+    add("kspJs", libs.koin.ksp.compiler)
+    add("kspJvm", libs.koin.ksp.compiler)
     debugImplementation(libs.leakcanary.android)
 }
 

--- a/convention-plugin-multiplatform/build.gradle.kts
+++ b/convention-plugin-multiplatform/build.gradle.kts
@@ -4,9 +4,11 @@ plugins {
 
 dependencies {
     compileOnly(libs.android.gradle.plugin)
+    compileOnly(libs.google.ksp.plugin)
     compileOnly(libs.jetbrains.compose.plugin)
     compileOnly(libs.kotlin.gradle.plugin)
     runtimeOnly(libs.android.gradle.plugin)
+    runtimeOnly(libs.google.ksp.plugin)
     runtimeOnly(libs.jetbrains.compose.compiler.plugin)
     runtimeOnly(libs.jetbrains.compose.plugin)
     runtimeOnly(libs.kotlin.gradle.plugin)

--- a/convention-plugin-multiplatform/src/main/kotlin/composeMultiplatformConvention.gradle.kts
+++ b/convention-plugin-multiplatform/src/main/kotlin/composeMultiplatformConvention.gradle.kts
@@ -1,4 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
 
@@ -10,24 +11,12 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(libs.findVersion("build-jvmTarget").get().requiredVersion.toInt())
 
     androidTarget {
-        compilations.all {
-            compileTaskProvider {
-                compilerOptions {
-                    jvmTarget.set(
-                        JvmTarget.fromTarget(
-                            libs.findVersion("build-jvmTarget").get().requiredVersion
-                        )
-                    )
-                    freeCompilerArgs.add(
-                        "-Xjdk-release=${JavaVersion.valueOf(
-                            libs.findVersion("build-javaVersion").get().requiredVersion
-                        )}"
-                    )
-                }
-            }
-        }
+        // https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     }
 
     jvm()
@@ -60,7 +49,6 @@ kotlin {
             implementation(libs.findLibrary("coil3-network-ktor").get())
             implementation(libs.findLibrary("jetbrains-lifecycle-viewmodel-compose").get())
             implementation(libs.findLibrary("jetbrains-navigation-compose").get())
-            implementation(libs.findLibrary("koin-annotations").get())
             implementation(libs.findLibrary("koin-core").get())
             implementation(libs.findLibrary("kotlinx-coroutines-core").get())
         }

--- a/convention-plugin-multiplatform/src/main/kotlin/composeMultiplatformKspConvention.gradle.kts
+++ b/convention-plugin-multiplatform/src/main/kotlin/composeMultiplatformKspConvention.gradle.kts
@@ -1,0 +1,29 @@
+val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+plugins {
+    id("composeMultiplatformConvention")
+    id("com.google.devtools.ksp")
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.findLibrary("koin-annotations").get())
+        }
+    }
+}
+
+dependencies {
+    // KSP Tasks
+    add("kspAndroid", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspCommonMainMetadata", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosArm64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosSimulatorArm64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosX64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspJs", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspJvm", libs.findLibrary("koin-ksp-compiler").get())
+}
+
+ksp {
+    arg("KOIN_CONFIG_CHECK", "true")
+}

--- a/core/coreCommon/build.gradle.kts
+++ b/core/coreCommon/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     id("testOptionsConvention")
-    alias(libs.plugins.google.ksp)
 }
 
 android {
     namespace = "siarhei.luskanau.pixabayeye.core.common"
     testOptions.configureTestOptions()
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/core/coreNetwork/build.gradle.kts
+++ b/core/coreNetwork/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     alias(libs.plugins.kotlinx.serialization)
     id("testOptionsConvention")
-    alias(libs.plugins.google.ksp)
 }
 
 android {
@@ -52,12 +51,4 @@ kotlin {
             implementation(libs.ktor.client.js)
         }
     }
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 cash-paging-compose-common = { module = "app.cash.paging:paging-compose-common", version.ref = "cash-paging" }
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
 coil3-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
+google-ksp-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "google-ksp" }
 inspektify-ktor3 = { module = "io.github.bvantur:inspektify-ktor3", version.ref = "inspektify" }
 javax-json-api = { module = "javax.json:javax.json-api", version.ref = "javax-json" }
 javax-json-glassfish = { module = "org.glassfish:javax.json", version.ref = "javax-json" }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("composeMultiplatformConvention")
     id("testOptionsConvention")
-    alias(libs.plugins.google.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
@@ -24,12 +23,4 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
         }
     }
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/ui/uiDetails/build.gradle.kts
+++ b/ui/uiDetails/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 android {
@@ -20,12 +19,4 @@ kotlin {
             implementation(project(":ui:uiCommon"))
         }
     }
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/ui/uiLogin/build.gradle.kts
+++ b/ui/uiLogin/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 android {
@@ -20,12 +19,4 @@ kotlin {
             implementation(project(":ui:uiCommon"))
         }
     }
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/ui/uiSearch/build.gradle.kts
+++ b/ui/uiSearch/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 android {
@@ -25,12 +24,4 @@ kotlin {
 
 dependencies {
     screenshotTestImplementation(libs.cash.paging.compose.common)
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/ui/uiSplash/build.gradle.kts
+++ b/ui/uiSplash/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("composeMultiplatformConvention")
+    id("composeMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 android {
@@ -20,12 +19,4 @@ kotlin {
             implementation(project(":ui:uiCommon"))
         }
     }
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }


### PR DESCRIPTION
This commit refactors the project to centralize the configuration of the Kotlin Symbol Processing (KSP) plugin.

The changes include:

- Creating a new convention plugin, `composeMultiplatformKspConvention`, which applies the `composeMultiplatformConvention` and the `com.google.devtools.ksp` plugin.
- Moving the KSP dependency and configuration to the `composeMultiplatformKspConvention` plugin.
- Updating modules to use the `composeMultiplatformKspConvention` plugin instead of `composeMultiplatformConvention` and applying the `com.google.devtools.ksp` plugin directly.
- Updating the `composeApp` module to explicitly add KSP dependencies for each source set.

This refactoring improves the maintainability and consistency of the project's build configuration by centralizing the KSP setup and removing redundant configurations in individual modules.