### PR TITLE
Build: Add jsBrowserDistribution task to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
 
       - run: ./gradlew ciBrowser --stacktrace
 
+      - run: ./gradlew jsBrowserDistribution --stacktrace
+
 
 
   iOS:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,7 @@ tasks.register("ciBrowser") {
     group = CI_GRADLE
     doLast {
         gradlew(":composeApp:jsMainClasses")
+        gradlew("jsBrowserDistribution")
     }
 }
 

--- a/core/coreNetwork/build.gradle.kts
+++ b/core/coreNetwork/build.gradle.kts
@@ -31,20 +31,8 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
         }
 
-        iosMain {
-            dependsOn(commonMain.get())
-            dependencies {
-                implementation(libs.ktor.client.darwin)
-            }
-        }
-        iosArm64Main {
-            dependsOn(iosMain.get())
-        }
-        iosX64Main {
-            dependsOn(iosMain.get())
-        }
-        iosSimulatorArm64Main {
-            dependsOn(iosMain.get())
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
 
         jsMain.dependencies {

--- a/core/corePref/build.gradle.kts
+++ b/core/corePref/build.gradle.kts
@@ -26,21 +26,9 @@ kotlin {
             implementation(libs.androidx.datastore.core.okio)
         }
 
-        iosMain {
-            dependsOn(commonMain.get())
-            dependencies {
-                implementation(libs.androidx.datastore.core.okio)
-                implementation(libs.kotlinx.serialization.json)
-            }
-        }
-        iosArm64Main {
-            dependsOn(iosMain.get())
-        }
-        iosX64Main {
-            dependsOn(iosMain.get())
-        }
-        iosSimulatorArm64Main {
-            dependsOn(iosMain.get())
+        iosMain.dependencies {
+            implementation(libs.androidx.datastore.core.okio)
+            implementation(libs.kotlinx.serialization.json)
         }
 
         jsMain.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ kotlinx-coroutines = "1.9.0"
 kotlinx-kover = "0.8.3"
 kotlinx-serialization = "1.7.3"
 ktlint = "1.5.0"
-ktor = "3.0.2"
+ktor = "3.0.1"
 leakcanary = "2.14"
 
 [libraries]


### PR DESCRIPTION
Adds the `jsBrowserDistribution` task to the CI workflow, ensuring that the browser distribution is built during the CI process. This task is responsible for creating the distributable artifacts for the web browser target.